### PR TITLE
Prevent assertion in get_action_name by introducing connection signals

### DIFF
--- a/addons/multiplayer_input/multiplayer_input.gd
+++ b/addons/multiplayer_input/multiplayer_input.gd
@@ -55,9 +55,7 @@ func reset():
 	if !Input.joy_connection_changed.is_connected(_on_joy_connection_changed):
 		Input.joy_connection_changed.connect(_on_joy_connection_changed)
 
-func _on_joy_connection_changed(device: int, connected: bool):
-	print(Input.get_connected_joypads())
-	
+func _on_joy_connection_changed(device: int, connected: bool):	
 	if connected:
 		device_connected.emit(device)
 		_create_actions_for_device(device)
@@ -173,7 +171,7 @@ func is_action_pressed(device: int, action: StringName, exact_match: bool = fals
 ## Returns the name of a gamepad-specific action
 func get_action_name(device: int, action: StringName) -> StringName:
 	if device >= 0:
-		assert(device_actions.has(device), "Device %s has no actions. Maybe the joypad is disconnected." % device)
+		assert(has_actions_for_device(device), "Device %s has no actions. Maybe the joypad is disconnected." % device)
 		# if it says this dictionary doesn't have the key,
 		# that could mean it's an invalid action name.
 		# or it could mean that action doesn't have a joypad event assigned


### PR DESCRIPTION
## What?
Introduced two signals: device_connected(device_id: int) and device_disconnected(device_id: int) to notify when input devices are added or removed.

Added has_action_registered(device_id: int, action_name: String) -> bool to check if a connected device has a specific input action assigned.

Nodes can now listen to these signals and verify that the device is connected and registered before querying input actions.

## Why?
Resolves the race condition highlighted in issue #8 where calling get_action_name() too early (before device_actions was populated) triggered an assertion error.

Ensures input handling occurs only when the device is fully initialized, improving runtime stability and preventing crashes.

## How?
Signals are emitted by the input manager whenever a device connects or disconnects.
has_action_registered() checks the internal mapping for action presence on the device.
Rather than relying on timing assumptions, users now listen to device_connected, call has_action_registered(), and only then proceed with input handling.

## Example

This is the default CharacterController2D provided by Godot edited to use signals and input device connection ecc...
` player_controller.gd `
```
func _ready() -> void:
	player_device_guid = Input.get_joy_guid(player_device)
	MultiplayerInput.device_connected.connect(_on_device_connected)
	MultiplayerInput.device_disconnected.connect(_on_device_disconnected)

func _on_device_connected(device: int) -> void:
	# Ignore device connected if it is controlled by the keyboard
	if(player_device == -1): 
		device_connected = true
		return
	
	# If a controller was reconnected with a new device index:
    # check GUID and update device index so the same controller stays assigned
	var guid = Input.get_joy_guid(device)
	if guid == player_device_guid:
		player_device = device  # update to new ID
		device_connected = true

func _on_device_disconnected(device: int) -> void:
	# Ignore device connected if it is controlled by the keyboard
	if(player_device == -1): return
	
    # If the disconnected device matches the assigned one, mark as disconnected
	if device == player_device:
		device_connected = false

# Assigns an input device to the CharacterController.
# Call this after instantiating the node (and before adding it to the scene).
func assign_device(device: int):
	player_device = device
	player_device_guid = Input.get_joy_guid(device)
	device_connected = true

func _physics_process(delta: float) -> void:
	# Add the gravity.
	if not is_on_floor():
		velocity += get_gravity() * delta
	
	if not device_connected:
		return
	
	# Handle jump.
	if MultiplayerInput.is_action_just_pressed(player_device, "ui_accept") and is_on_floor():
		velocity.y = JUMP_VELOCITY

	# Get the input direction and handle the movement/deceleration.
	# As good practice, you should replace UI actions with custom gameplay actions.
	var direction := MultiplayerInput.get_axis(player_device, "ui_left", "ui_right")
	if direction:
		velocity.x = direction * SPEED
	else:
		velocity.x = move_toward(velocity.x, 0, SPEED)

	move_and_slide()
```